### PR TITLE
Started City Data Display

### DIFF
--- a/app/scripts/data_processing.py
+++ b/app/scripts/data_processing.py
@@ -1,0 +1,8 @@
+import pandas as pd
+
+# Filter and load the location names and its population densities
+pop_density = pd.read_csv("../datasets/WPP2024_Demographic_Indicators.csv")
+pop_density = pd.read_csv("../datasets/WPP2024_Demographic_Indicators.csv", usecols=["Location", "PopDensity"])
+
+# Print the filtered data for testing purposes
+print(pop_density)

--- a/app/scripts/data_processing.py
+++ b/app/scripts/data_processing.py
@@ -1,8 +1,0 @@
-import pandas as pd
-
-# Filter and load the location names and its population densities
-pop_density = pd.read_csv("../datasets/WPP2024_Demographic_Indicators.csv")
-pop_density = pd.read_csv("../datasets/WPP2024_Demographic_Indicators.csv", usecols=["Location", "PopDensity"])
-
-# Print the filtered data for testing purposes
-print(pop_density)

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -45,9 +45,17 @@ function GeoLocate() {
         })
             .on("markgeocode", function (e) {
                 var latlng = e.geocode.center;
+
+                // Extract city, state, and country from the geocoding result (with default values if it is missing)
+                const properties = e.geocode.properties.address || {};
+                const city = properties.city || properties.town || properties.village || "Gainesville";
+                const state = properties.state || "Florida";
+                const country = properties.country || "United States";
+
+                // Displaying extracted information in the popup for testing purposes
                 L.marker(latlng, { icon })
                     .addTo(map)
-                    .bindPopup(e.geocode.name)
+                    .bindPopup(`${city}, ${state}, ${country}`)
                     .openPopup();
                 map.fitBounds(e.geocode.bbox);
             })


### PR DESCRIPTION
This pull request focuses on integrating the use of the Zippopotam.us API with the leaflet control geocoder by extracting the suggested search input, converting it to the necessary formatting for API use, and using the API to get and display information on the city. Due to required fields and abbreviations, the information for other countries out of the United States cannot be displayed properly yet, and the required fields leads to the use of default values as temporary placeholders for when any field is missing. There is also an undefined postal code error that needs fixing. This is just the first implementation with the API that displays data for US cities, but more work has to be done for other locations, more city information, improved accuracy, and better design. (Note: use npm install to install new us-state-codes package.)